### PR TITLE
Accept qdbus-qt5 next to qdbus

### DIFF
--- a/winspotlightkde
+++ b/winspotlightkde
@@ -45,9 +45,17 @@ imgName=${imgPath}/${dateTime}.jpeg
 # Download the image
 curl -s $imageURL -o ${imgName}
 
+for cmd in qdbus qdbus-qt5
+do
+    if command -v $cmd >/dev/null; then
+        qdbus=$cmd
+        break
+    fi
+done
+
 # Set the wallpaper for the desktop
 if [ "$setDesktop" == "yes" ]; then
-        qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "var allDesktops = desktops();
+        $qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "var allDesktops = desktops();
         print (allDesktops);for (i=0;i<allDesktops.length;i++) {d = allDesktops[i];d.wallpaperPlugin = 'org.kde.image';
         d.currentConfigGroup = Array('Wallpaper', 'org.kde.image', 'General');d.writeConfig('Image', 'file://${imgName}')}"
 fi


### PR DESCRIPTION
Keeping trying qdbus as a first option, but if it's not available, try qdbus-qt5 as well, which is what e.g. openSUSE Leap 15 provides.